### PR TITLE
Use `mp_pause_match` before loading round backup

### DIFF
--- a/backend/src/match.ts
+++ b/backend/src/match.ts
@@ -351,7 +351,7 @@ export const getRoundBackups = async (match: Match, count: number = 5) => {
 };
 
 export const loadRoundBackup = async (match: Match, file: string) => {
-	await execRcon(match, 'mp_backup_restore_load_autopause 1');
+	await execRcon(match, 'mp_pause_match');
 	const response = await execRcon(match, `mp_backup_restore_load_file "${file}"`);
 	if (response.includes('Failed to load file:')) {
 		match.log(`Error loading round backup: ${response}`);


### PR DESCRIPTION
In CS2 `mp_backup_restore_load_autopause` does not seem to work, but executing `mp_pause_match` before loading the backup pauses the match after the round has been restored.